### PR TITLE
fix: improve docs and mongo validation handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,52 +2,29 @@
 
 ![Statements](https://img.shields.io/badge/statements-96.8%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.02%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-96.96%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-96.66%25-brightgreen.svg?style=flat)
 
-A fastify Papr plugin integration.
+**Type-safe MongoDB for Fastify.** A first-class [Papr](https://plexinc.github.io/papr/) integration that turns your schemas into fully typed collections, decorated right onto your Fastify instance — no boilerplate, no `any`, no runtime surprises.
 
-This package is distributed as ESM-only.
-
-## Tooling
-
-This package uses `Vite+` for packaging, testing, formatting, and static checks while keeping `pnpm` scripts as the main interface:
-
-```bash
-pnpm build
-pnpm test
-pnpm lint
-pnpm coverage
+```ts
+const user = await fastify.papr.user.insertOne(req.body) // fully typed, validated, ready
 ```
 
-The published package ships a single ESM build plus declarations in `dist/`.
+## Why fastify-papr?
 
-## Getting started
+- **End-to-end type safety** — Papr schemas become TypeScript types automatically. Your routes, queries, and inserts are checked at compile time.
+- **MongoDB-native validation** — Schemas compile to native MongoDB `$jsonSchema` validators, so invalid data is rejected at the database layer, not just in application code.
+- **First-class error handling** — `MongoValidationError` parses MongoDB's cryptic validation errors into structured, field-level details you can return to clients.
+- **Zero-ceremony DI** — Register models once with `asCollection(...)`, access them anywhere via `fastify.papr.<model>`.
+- **Modern by default** — ESM-only, Node.js `>=22.12.0`, built on top of `@fastify/mongodb`.
+
+## Install
 
 ```bash
 pnpm add @inaiat/fastify-papr @fastify/mongodb
 ```
 
-Runtime requirement: Node.js `>=22.12.0`.
+## Quick start
 
-## Breaking Changes in v12.0.0
-
-- The package is now distributed as ESM-only.
-- The CommonJS bundle (`dist/index.cjs`) is no longer published.
-- The minimum supported Node.js version is now `22.12.0`.
-
-### Migration Guide
-
-- Prefer ESM imports:
-
-```ts
-import fastifyPaprPlugin, { asCollection } from '@inaiat/fastify-papr'
-```
-
-- If you still consume it from CommonJS on modern Node.js, load the ESM default export explicitly:
-
-```js
-const { default: fastifyPaprPlugin, asCollection } = require('@inaiat/fastify-papr')
-```
-
-Next, set up the plugin:
+Define a schema, register the plugin, and you're done:
 
 ```ts
 import fastifyMongodb from '@fastify/mongodb'
@@ -87,13 +64,14 @@ export default fp<FastifyPaprOptions>(
 )
 ```
 
-How to use:
+## Using your models
+
+Access fully typed collections anywhere through `fastify.papr`:
 
 ```ts
 import { FastifyPluginAsync } from 'fastify'
 import { Static, Type } from '@sinclair/typebox'
-import { MongoServerError } from 'mongodb'
-import { MongoValidationError, isMongoServerError } from '@inaiat/fastify-papr'
+import { extractValidationErrors, isMongoServerError } from '@inaiat/fastify-papr'
 
 const userDto = Type.Object({
   name: Type.String({ maxLength: 100, minLength: 10 }),
@@ -103,37 +81,19 @@ const userDto = Type.Object({
 const userRoute: FastifyPluginAsync = async (fastify) => {
   fastify.post<{ readonly Body: Static<typeof userDto> }>(
     '/user',
-    {
-      schema: {
-        body: userDto,
-      },
-    },
+    { schema: { body: userDto } },
     async (req, reply) => {
       try {
-        const result = await fastify.papr.user.insertOne(req.body)
-        return result
+        return await fastify.papr.user.insertOne(req.body)
       } catch (error) {
-        // Check if it's a MongoDB validation error
         if (isMongoServerError(error) && error.code === 121) {
-          const validationError = new MongoValidationError(error)
-
-          // Log or process the validation details
-          console.error('Validation failed:', validationError.getValidationErrorsAsString())
-
-          // Example: Get errors for a specific field
-          const nameErrors = validationError.getFieldErrors('name')
-          if (nameErrors) {
-            console.error('Name field errors:', nameErrors)
+          const details = extractValidationErrors(error)
+          if (details) {
+            fastify.log.error({ details }, 'validation failed')
+            return reply.status(400).send({ message: 'Validation failed', errors: details })
           }
-
-          // Return a 400 Bad Request with validation details
-          return reply.status(400).send({
-            message: 'Validation failed',
-            errors: validationError.validationErrors,
-          })
         }
 
-        // Handle other errors
         fastify.log.error(error)
         return reply.status(500).send({ message: 'Internal Server Error' })
       }
@@ -144,17 +104,46 @@ const userRoute: FastifyPluginAsync = async (fastify) => {
 export default userRoute
 ```
 
-## Breaking Changes in v9.0.0
+If you need field-level inspection after the MongoDB validation guard, wrap the error in `MongoValidationError` and use helpers like `getFieldErrors('name')`.
 
-### MongoDB Validation Error Handling
+## Learn more
 
-We've consolidated and improved the MongoDB validation error handling in v2.0.0:
+- [Papr documentation](https://plexinc.github.io/papr/) — schema options, operators, and advanced queries
+- Explore the `tests/` folder in this repo for runnable examples
 
-- The `SimpleDocFailedValidationError` and related types have been replaced with a new `MongoValidationError` class
-- The error extraction logic has been improved for better type safety and reliability
-- New helper methods have been added for easier access to validation errors
+---
 
-#### Migration Guide
+## Requirements
+
+- Node.js `>=22.12.0`
+- MongoDB server (any version supported by the official driver)
+- ESM — this package is published as ESM-only
+
+## Breaking changes in v12.0.0
+
+- The package is now distributed as ESM-only.
+- The CommonJS bundle (`dist/index.cjs`) is no longer published.
+- The minimum supported Node.js version is now `22.12.0`.
+
+### Migration
+
+Prefer ESM imports:
+
+```ts
+import fastifyPaprPlugin, { asCollection } from '@inaiat/fastify-papr'
+```
+
+If you still consume it from CommonJS on modern Node.js, load the ESM default export explicitly:
+
+```js
+const { default: fastifyPaprPlugin, asCollection } = require('@inaiat/fastify-papr')
+```
+
+## Breaking changes in v9.0.0
+
+### MongoDB validation error handling
+
+`SimpleDocFailedValidationError` was replaced with a consolidated `MongoValidationError` class with better type safety and new helper methods.
 
 Replace imports:
 
@@ -176,14 +165,13 @@ Use the new class and methods:
 + const errorJson = validationError.getValidationErrorsAsString()
 ```
 
-New features:
+New: get validation errors for a specific field:
 
-```typescript
-// Get validation errors for a specific field
+```ts
 const nameErrors = validationError.getFieldErrors('name')
 ```
 
-Type changes:
+Type renames:
 
 ```diff
 - DocumentFailedValidation → DocumentValidationError
@@ -192,6 +180,15 @@ Type changes:
 - SimpleDocFailedValidation → ValidationErrors
 ```
 
-## Papr Documentation and examples
+## Development
 
-To learn more about the code and see additional examples, you can visit the Papr documentation at [plexinc.github.io/papr](https://plexinc.github.io/papr/) and explore test folder on this project.
+This package uses `Vite+` for packaging, testing, formatting, and static checks. `pnpm` scripts are the main interface:
+
+```bash
+pnpm build
+pnpm test
+pnpm lint
+pnpm coverage
+```
+
+The published package ships a single ESM build plus declarations in `dist/`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inaiat/fastify-papr",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Fastify Papr Plugin Integration",
   "keywords": [
     "database",

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -7,36 +7,46 @@ description: Use when the task involves integrating `@inaiat/fastify-papr` into 
 
 ## Overview
 
-Use this skill when working with `@inaiat/fastify-papr` as a consumer or when updating the library itself. It covers the stable usage patterns for setup, model registration, typing, multi-database access, and MongoDB validation error handling.
+Use this skill when working with `@inaiat/fastify-papr` as a consumer or when updating the library itself. It covers the stable usage patterns for dependency setup, model registration, typing, multi-database access, schema reconciliation, and MongoDB validation error handling.
 
 ## Quick Rules
 
 - Treat the package as ESM-only. Prefer `import fastifyPaprPlugin, { asCollection } from '@inaiat/fastify-papr'`.
-- Assume Node.js `>=22.12.0` and MongoDB driver `>=7`.
+- Assume Node.js `>=22.12.0`, Fastify `>=5.8`, and MongoDB driver `>=7`.
+- Consumers usually need `fastify`, `@fastify/mongodb`, `mongodb`, and `papr` installed explicitly alongside this package.
 - Register `@fastify/mongodb` before registering this plugin, and pass a concrete `Db` instance as `options.db`.
 - Build model registrations with `asCollection(...)` instead of hand-writing objects.
+- The `models` object key becomes the property on `fastify.papr`; the first argument to `asCollection` is the MongoDB collection name.
 - Prefer one access pattern per app: either direct models on `fastify.papr` or named connections such as `fastify.papr.db1`.
+- Do not register unnamed models twice, and do not reuse a named connection. Both cases throw during plugin registration.
+- Leave schema reconciliation enabled unless collection validators are managed outside the app.
 - In consumers, augment the public module path `'@inaiat/fastify-papr'`, not internal source files.
-- For MongoDB schema validation failures, first narrow with `isMongoServerError(error) && error.code === 121`, then use `MongoValidationError`.
+- For MongoDB schema validation failures, narrow with `isMongoServerError(error) && error.code === 121` before calling `extractValidationErrors(error)` or instantiating `MongoValidationError`.
 
 ## Workflow
 
-1. Confirm the integration shape.
+1. Confirm the runtime and dependency shape first.
+   Check that the consumer is using ESM, Node.js `>=22.12.0`, Fastify `>=5.8`, and MongoDB driver `>=7`. If the setup example omits `papr`, `fastify`, or `mongodb`, add them explicitly.
+
+2. Confirm the integration shape.
    Use the default export as the Fastify plugin, register Mongo first, then register Papr models with `asCollection`.
 
-2. Decide the model access pattern early.
+3. Decide the model access pattern early.
    If the service only uses one database, prefer direct models such as `fastify.papr.user`. If it uses multiple databases, register each connection with `options.name` and access models through `fastify.papr.<connectionName>.<modelName>`.
 
-3. Make types explicit.
-   Derive model types from schemas with `PaprModel<typeof schema>`. When consumers need typed access through `fastify.papr`, add module augmentation for `FastifyPapr`.
+4. Make types explicit.
+   Derive model types from schemas with `PaprModel<typeof schema>`. When consumers need typed access through `fastify.papr`, add module augmentation for `FastifyPapr`. If the task is inside this library repo, keep the public package path for user-facing examples and use the type tests to verify exported types.
 
-4. Keep validation handling structured.
-   Do not parse `errInfo` inline in route handlers. Wrap validation errors with `MongoValidationError`, log or return the structured `validationErrors`, and use `getFieldErrors` only when field-specific branching is necessary.
+5. Check registration behavior, not just happy-path usage.
+   Make sure examples describe how collection names map to Fastify properties, where indexes are defined, and when `disableSchemaReconciliation` is appropriate. If the task touches registration semantics, mention duplicate-registration failure modes.
 
-5. Preserve the public contract when changing the library.
+6. Keep validation handling structured.
+   Do not parse `errInfo` inline in route handlers. Return the structured payload from `extractValidationErrors(error)` when that is enough, or wrap with `MongoValidationError` when field-level branching or richer logging is needed.
+
+7. Preserve the public contract when changing the library.
    If exports, helper types, or validation helpers change, update the consumer-facing type tests and the README examples in the same change.
 
 ## References
 
-- For setup, registration patterns, indexes, schema reconciliation, and multi-database guidance, read [references/integration.md](references/integration.md).
-- For exported type helpers, augmentation patterns, and validation error handling, read [references/types-and-errors.md](references/types-and-errors.md).
+- For setup, dependency constraints, registration patterns, indexes, schema reconciliation, and multi-database guidance, read [references/integration.md](references/integration.md).
+- For exported type helpers, augmentation patterns, duplicate-key vs validation handling, and `MongoValidationError` usage, read [references/types-and-errors.md](references/types-and-errors.md).

--- a/skill/agents/openai.yaml
+++ b/skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: 'Fastify Papr'
   short_description: 'Use and best practices for fastify-papr'
-  default_prompt: 'Use $fastify-papr to integrate Papr with Fastify, model collections safely, and handle Mongo validation errors correctly.'
+  default_prompt: 'Use $fastify-papr to integrate Papr with Fastify, register typed models safely, choose the right single-db or multi-db pattern, and handle Mongo validation errors correctly.'

--- a/skill/references/integration.md
+++ b/skill/references/integration.md
@@ -4,14 +4,23 @@
 
 - The package is ESM-only.
 - The supported runtime floor is Node.js `22.12.0`.
+- The supported Fastify peer range starts at `5.8`.
+- The supported MongoDB driver major is `7`.
 - The plugin expects a MongoDB `Db` instance, not just a connection string.
 - Register `@fastify/mongodb` before `@inaiat/fastify-papr`.
+- Consumers normally install `fastify`, `@fastify/mongodb`, `mongodb`, `papr`, and `@inaiat/fastify-papr` together.
 
 Minimal import shape:
 
 ```ts
 import fastifyMongodb from '@fastify/mongodb'
 import fastifyPaprPlugin, { asCollection } from '@inaiat/fastify-papr'
+```
+
+Typical install shape:
+
+```bash
+pnpm add fastify @fastify/mongodb mongodb papr @inaiat/fastify-papr
 ```
 
 ## Default single-database registration
@@ -41,6 +50,12 @@ export default fp<FastifyPaprOptions>(async (fastify) => {
   })
 })
 ```
+
+Notes:
+
+- The `user` key in `models` becomes `fastify.papr.user`.
+- The first argument to `asCollection` is the actual MongoDB collection name.
+- If you register unnamed models a second time on the same Fastify instance, the plugin throws with the already-registered model keys.
 
 ## Multiple database registration
 
@@ -72,6 +87,7 @@ Best practices:
 - Do not reuse the same connection name twice. The plugin throws on duplicates.
 - Avoid mixing unnamed and named registrations in the same app. Pick one access pattern and keep it consistent.
 - Keep the Fastify property names stable and map them intentionally to MongoDB collection names.
+- Reserve named registration for real multi-database cases. If all models share one `Db`, the unnamed pattern is simpler and produces cleaner access.
 
 ## Collection naming and indexes
 
@@ -89,6 +105,7 @@ Best practices:
 
 - Use singular or plural names consistently across the app.
 - Put index definitions next to the schema registration so the collection contract is reviewable in one place.
+- Remember that indexes passed to `asCollection` are created during plugin registration.
 - Keep the `models` keys descriptive; they become part of the consumer-facing application API.
 
 ## Schema reconciliation
@@ -104,3 +121,9 @@ await fastify.register(fastifyPaprPlugin, {
 ```
 
 Prefer leaving reconciliation enabled unless there is a concrete operational reason to skip it.
+
+Use `disableSchemaReconciliation: true` only when:
+
+- Collection validators are managed by migrations or platform tooling outside the service.
+- Startup should not attempt to mutate collection validation rules.
+- The team is intentionally separating schema enforcement rollout from app deploys.

--- a/skill/references/types-and-errors.md
+++ b/skill/references/types-and-errors.md
@@ -9,6 +9,7 @@ The library exports helper types for building a typed application layer around P
 - `PaprSchemaDefinition<TSchema>`: schema options derived from a schema tuple
 - `PaprModel<TSchema>`: concrete Papr model type for a schema tuple
 - `FastifyPapr`: augmented shape exposed at `fastify.papr`
+- `FastifyPaprModel` and `FastifyPaprConnection`: lower-level model and named-connection building blocks
 - `FastifyPaprOptions`: plugin options
 - `ModelRegistration` and `ModelRegistrationPair`: registration helpers used by the plugin
 
@@ -48,6 +49,7 @@ Best practices:
 
 - Augment only the keys your service actually registers.
 - Keep augmentation next to the plugin-registration module or in a dedicated types module loaded by TypeScript.
+- For named connections, model the nested shape explicitly instead of falling back to broad index signatures.
 - When working inside this library repo, use the type tests as the contract for exported helpers.
 
 ## Type-test guidance for this repo
@@ -62,9 +64,28 @@ Use `expectTypeOf` for compile-time contracts. Prefer tests that prove the publi
 
 ## Validation error handling
 
-`isMongoServerError` is only the first gate. For schema validation failures, also check `error.code === 121`.
+Use `isMongoServerError(error) && error.code === 121` before calling `extractValidationErrors(error)` or creating `MongoValidationError`. This keeps the validation path limited to real MongoDB validation failures and avoids treating lookalike errors as Mongo server errors.
 
 Recommended route pattern:
+
+```ts
+import { extractValidationErrors, isMongoServerError } from '@inaiat/fastify-papr'
+
+try {
+  await fastify.papr.user.insertOne(req.body)
+} catch (error) {
+  if (isMongoServerError(error) && error.code === 121) {
+    const details = extractValidationErrors(error)
+    if (details) {
+      return reply.status(400).send({ message: 'Validation failed', errors: details })
+    }
+  }
+
+  throw error
+}
+```
+
+When route behavior depends on a specific field failure or you need richer logs, use `MongoValidationError`:
 
 ```ts
 import { MongoValidationError, isMongoServerError } from '@inaiat/fastify-papr'
@@ -74,6 +95,12 @@ try {
 } catch (error) {
   if (isMongoServerError(error) && error.code === 121) {
     const validationError = new MongoValidationError(error)
+
+    fastify.log.warn({ validation: validationError.getValidationErrorsAsString() }, 'mongo schema validation failed')
+
+    if (validationError.getFieldErrors('email') !== undefined) {
+      return reply.status(400).send({ message: 'Email is invalid' })
+    }
 
     return reply.status(400).send({
       message: 'Validation failed',
@@ -85,9 +112,11 @@ try {
 }
 ```
 
+Use `isMongoServerError` when you need to distinguish other Mongo server errors as well, such as duplicate key errors with `code === 11000`.
+
 Prefer these helpers over manual `errInfo` traversal:
 
-- `extractValidationErrors(error)`: returns the simplified structured error payload or `undefined`
+- `extractValidationErrors(error)`: accepts `unknown`; returns the simplified structured payload or `undefined`
 - `new MongoValidationError(error)`: wraps the Mongo error and exposes helper methods
 - `validationErrors`: structured validation payload
 - `hasValidationFailures`: boolean shortcut
@@ -98,4 +127,5 @@ Best practices:
 
 - Return the structured `validationErrors` payload to API clients when appropriate.
 - Use `getValidationErrorsAsString()` for logs, not as the primary application contract.
+- Expect `hasValidationFailures === false` for non-validation `MongoServerError` values such as duplicate-key errors.
 - Avoid treating every `MongoServerError` as a validation error; duplicate key and other server errors need different handling.

--- a/src/mongo-validation-error.ts
+++ b/src/mongo-validation-error.ts
@@ -43,6 +43,10 @@ export type DocumentValidationError = {
         operatorName: string
         /** Properties that didn't satisfy the validation rules */
         propertiesNotSatisfied?: readonly ValidationProperty[] | null
+        /** Names of properties that were present but not allowed by the schema (for the `additionalProperties` rule) */
+        additionalProperties?: readonly string[] | null
+        /** The specification that was violated for this rule */
+        specifiedAs?: Record<string, unknown>
       },
     ]
   }
@@ -60,11 +64,7 @@ export type ValidationErrors = Record<string, Record<string, ValidationDetail[]>
  * @returns True if the error is a MongoDB server error
  */
 export function isMongoServerError(error: unknown): error is MongoServerError {
-  if (error instanceof MongoServerError) {
-    return true
-  }
-
-  return error instanceof Error && 'code' in error && typeof error.code === 'number'
+  return error instanceof MongoServerError
 }
 
 /**
@@ -78,10 +78,10 @@ const formatValidationProperties = (properties: readonly ValidationProperty[]) =
 
 /**
  * Attempts to extract validation error details from a MongoDB server error
- * @param error The MongoDB server error to process
+ * @param error The error to process — may be any unknown value
  * @returns A simplified representation of validation errors or undefined if not a validation error
  */
-export function extractValidationErrors(error: Readonly<MongoServerError>): ValidationErrors | undefined {
+export function extractValidationErrors(error: unknown): ValidationErrors | undefined {
   // Check if this is actually a MongoDB validation error
   if (!isMongoServerError(error) || error.code !== 121) {
     return undefined
@@ -96,9 +96,30 @@ export function extractValidationErrors(error: Readonly<MongoServerError>): Vali
   const schemaRulesNotSatisfied = errInfo.details.schemaRulesNotSatisfied
 
   // Transform the schema rules into a more user-friendly format
-  const result: ValidationErrors = schemaRulesNotSatisfied.map((rule) => ({
-    [rule.operatorName]: formatValidationProperties(rule.propertiesNotSatisfied ?? []),
-  }))
+  const result: ValidationErrors = schemaRulesNotSatisfied.map((rule) => {
+    const additionalProps = rule.additionalProperties
+    if (
+      rule.operatorName === 'additionalProperties' &&
+      additionalProps !== undefined &&
+      additionalProps !== null &&
+      additionalProps.length > 0
+    ) {
+      const detail: ValidationDetail = {
+        operatorName: 'additionalProperties',
+        specifiedAs: rule.specifiedAs,
+        reason: 'property is not allowed by the schema',
+      }
+      const properties = additionalProps.map((propertyName) => ({
+        propertyName,
+        details: [detail],
+      }))
+      return { [rule.operatorName]: formatValidationProperties(properties) }
+    }
+
+    return {
+      [rule.operatorName]: formatValidationProperties(rule.propertiesNotSatisfied ?? []),
+    }
+  })
 
   return result.length > 0 ? result : undefined
 }

--- a/tests/mongo-validation-error.types.test.ts
+++ b/tests/mongo-validation-error.types.test.ts
@@ -73,6 +73,8 @@ describe('mongo validation error types', () => {
           {
             operatorName: string
             propertiesNotSatisfied?: readonly ValidationProperty[] | null
+            additionalProperties?: readonly string[] | null
+            specifiedAs?: Record<string, unknown>
           },
         ]
       }
@@ -86,7 +88,7 @@ describe('mongo validation error types', () => {
   })
 
   it('exposes the expected function and class signatures', () => {
-    expectTypeOf(extractValidationErrors).parameters.toEqualTypeOf<[Readonly<MongoServerError>]>()
+    expectTypeOf(extractValidationErrors).parameters.toEqualTypeOf<[unknown]>()
     expectTypeOf(extractValidationErrors).returns.toEqualTypeOf<ValidationErrors>()
     expectTypeOf<MongoValidationError['getValidationErrorsAsString']>().parameters.toEqualTypeOf<[]>()
     expectTypeOf<MongoValidationError['getValidationErrorsAsString']>().returns.toEqualTypeOf<string | undefined>()

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -36,6 +36,24 @@ const assertFieldError = (
   equal(fieldErrors?.[0]?.operatorName, expectedOperatorName)
 }
 
+const assertAdditionalPropertiesCaptured = (
+  validationError: MongoValidationError,
+  expectedFields: readonly string[],
+) => {
+  const additionalPropsRule = validationError.validationErrors?.[0]?.additionalProperties
+  ok(additionalPropsRule, 'expected additionalProperties rule to be captured')
+  const flaggedFields = new Set(additionalPropsRule.flatMap((entry) => Object.keys(entry)))
+  equal(flaggedFields.size, expectedFields.length)
+
+  for (const fieldName of expectedFields) {
+    ok(flaggedFields.has(fieldName), `expected ${fieldName} to be flagged as additional`)
+    const fieldErrors = validationError.getFieldErrors(fieldName)
+    equal(fieldErrors?.length, 1)
+    equal(fieldErrors?.[0]?.operatorName, 'additionalProperties')
+    deepEqual(fieldErrors?.[0]?.specifiedAs, { additionalProperties: false })
+  }
+}
+
 const assertDocumentFailedWithNameAndAge = (error: unknown) => {
   const validationError = getValidationError(error)
 
@@ -59,8 +77,13 @@ const assertDocumentFailedWithNameAndAge = (error: unknown) => {
   return true
 }
 
-const assertNonMongoServerErrors = (genericError: Error, notAnError: { code: number; message: string }) => {
+const assertNonMongoServerErrors = (
+  genericError: Error,
+  errorWithCode: Error & { code: number },
+  notAnError: { code: number; message: string },
+) => {
   equal(isMongoServerError(genericError), false)
+  equal(isMongoServerError(errorWithCode), false)
   equal(isMongoServerError(notAnError), false)
   equal(isMongoServerError(null), false)
 }
@@ -173,6 +196,40 @@ describe('Validation', () => {
     await rejects(async () => papr.user.insertOne(user), assertDocumentFailedWithNameAndAge)
   })
 
+  it('document failed with additional properties', async () => {
+    const { server: fastify } = getConfiguredTestServer()
+
+    await fastify.register(fastifyPaprPlugin, {
+      db: mut_mongoContext.db,
+      models: {
+        user: asCollection('user', userSchema),
+      },
+    })
+    const papr = fastify.papr
+    if (!hasUserModel(papr)) {
+      throw new Error('User model not registered')
+    }
+
+    const userCollection = mut_mongoContext.db.collection('user')
+    const userWithExtras = {
+      name: 'Valid Name',
+      phone: '552124561234',
+      age: 40,
+      email: 'extra@example.com',
+      nickname: 'extra-nick',
+    }
+    await rejects(
+      async () => userCollection.insertOne(userWithExtras),
+      (error) => {
+        const validationError = getValidationError(error)
+        ok(validationError.hasValidationFailures)
+        assertAdditionalPropertiesCaptured(validationError, ['email', 'nickname'])
+        equal(validationError.getFieldErrors('name'), undefined)
+        return true
+      },
+    )
+  })
+
   it('simple doc failed validation should result undefined when schema rules not satisfied', async () => {
     const { server: fastify } = getConfiguredTestServer()
 
@@ -224,8 +281,21 @@ describe('Validation', () => {
 
     ok(isMongoServerError(validationError))
     ok(isMongoServerError(duplicateKeyError))
-    ok(isMongoServerError(errorWithCode))
-    assertNonMongoServerErrors(genericError, notAnError)
+    assertNonMongoServerErrors(genericError, errorWithCode, notAnError)
+  })
+
+  void it('extractValidationErrors accepts unknown and returns undefined for non-Mongo errors', () => {
+    const fakeMongoValidationError = Object.assign(new Error('boom'), {
+      code: 121,
+      errInfo: sample1,
+    })
+
+    equal(extractValidationErrors(new Error('boom')), undefined)
+    equal(extractValidationErrors(fakeMongoValidationError), undefined)
+    equal(extractValidationErrors({ message: 'fake', code: 121 }), undefined)
+    equal(extractValidationErrors(null), undefined)
+    equal(extractValidationErrors(undefined), undefined) // eslint-disable-line eslint-plugin-unicorn/no-useless-undefined
+    equal(extractValidationErrors('not an error'), undefined)
   })
 
   void it('extractValidationErrors edge cases', () => {


### PR DESCRIPTION
## Summary

This PR improves the consumer-facing documentation for `@inaiat/fastify-papr` and aligns the internal skill docs with the package's actual runtime and typing contract. It also hardens the Mongo validation error helpers to better handle `unknown` inputs and additional validation cases.

## What changed

- rewrote the README to better explain the package value proposition, setup flow, typed model usage, runtime requirements, and migration notes
- expanded the internal `skill/` documentation with clearer guidance for:
  - dependency and runtime constraints
  - single-db vs multi-db registration
  - model key vs collection name mapping
  - schema reconciliation behavior
  - type augmentation and validation error handling
- updated the skill agent prompt so it steers toward the correct registration and error-handling patterns
- bumped the package version from `12.0.0` to `12.0.1`

## Validation helper updates

- widened `extractValidationErrors` to accept `unknown` instead of only `MongoServerError`
- kept validation parsing gated behind `isMongoServerError(error) && error.code === 121`
- added support for `additionalProperties` validation details in the extracted error payload
- updated type tests and runtime tests to cover:
  - `additionalProperties`
  - non-validation Mongo errors
  - non-Mongo lookalike errors
  - the new `unknown` parameter contract

## Validation

- `pnpm lint`